### PR TITLE
Remove team name from button on join team page

### DIFF
--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -85,7 +85,7 @@ join-team-title = You have been invited to join { $team }
 
 join-team-reject = Reject
 
-join-team-accept = Join { $team }
+join-team-accept = Join team
 
 
 

--- a/locales/pl.ftl
+++ b/locales/pl.ftl
@@ -83,7 +83,7 @@ join-team-title = Zostałeś/aś zaproszony/a do dołączenia do zespołu { $tea
 
 join-team-reject = Odrzuć
 
-join-team-accept = Dołącz do { $team }
+join-team-accept = Dołącz do zespołu
 
 
 

--- a/templates/pages/join-team.html
+++ b/templates/pages/join-team.html
@@ -16,7 +16,7 @@
         <form method="post">
             <input type="hidden" name="invite" value="{{ invite }}" required>
             <input type="hidden" name="action" value="accept" required>
-            <input type="submit" value="{{ _(key="join-team-accept", team=team) }}">
+            <input type="submit" value="{{ _(key="join-team-accept") }}">
         </form>
     </div>
 {% endblock %}


### PR DESCRIPTION
Button text was too long:
![obraz](https://user-images.githubusercontent.com/31478212/66469090-87b85580-ea87-11e9-917a-286a8dea97a1.png)
